### PR TITLE
Integrate ghost newsletter signup for landing pages

### DIFF
--- a/GHOST_SETUP.md
+++ b/GHOST_SETUP.md
@@ -1,0 +1,121 @@
+# Ghost Headless CMS Setup Guide
+
+## Current Status
+✅ **Newsletter Integration Complete**: Ghost newsletter signup forms are now integrated into all landing pages:
+- Products page (`/products`)
+- Study page (`/study`) 
+- Supervisors page (`/supervisors`)
+- Dedicated subscribe page (`/subscribe`)
+
+## Ghost Configuration Needed
+
+### 1. Ghost Instance Setup
+You need a Ghost instance running at `https://behaviorschool.com`. Based on the code, it appears you already have this.
+
+### 2. Environment Variables Required
+Copy `.env.example` to `.env.local` and configure:
+
+```bash
+# Ghost Content API URL (your Ghost site URL)
+GHOST_CONTENT_URL=https://behaviorschool.com
+
+# Ghost Content API Key (get from Ghost Admin)
+GHOST_CONTENT_KEY=your_actual_content_api_key
+
+# Optional webhook configuration
+GHOST_WEBHOOK_SECRET=your_webhook_secret
+GHOST_WEBHOOK_TOKEN=your_webhook_token
+```
+
+### 3. Getting Your Ghost Content API Key
+
+1. **Access Ghost Admin**: Go to `https://behaviorschool.com/ghost/`
+2. **Navigate to Integrations**: Settings → Integrations
+3. **Add Custom Integration**: 
+   - Click "Add custom integration"
+   - Name it something like "Behavior School Frontend"
+   - Copy the **Content API Key** (not the Admin API Key)
+4. **Update Environment**: Add the key to your `.env.local` file
+
+### 4. Newsletter Feature Setup
+
+The newsletter signup forms use Ghost's native signup form widget (`@~0.2/umd/signup-form.min.js`) which:
+- ✅ Automatically handles subscription management
+- ✅ Integrates with Ghost's built-in email system
+- ✅ Provides responsive design
+- ✅ Supports customization (colors, text, etc.)
+
+### 5. Current Newsletter Configurations
+
+#### Products Page
+- **Title**: "Behavior School Updates"
+- **Description**: "Join thousands of BCBAs getting weekly insights on effective behavior management and professional growth."
+- **Button Color**: `#dfbf7c` (brand gold)
+
+#### Study Page  
+- **Title**: "BCBA Study Newsletter"
+- **Description**: "Weekly study strategies, practice questions, and exam preparation tips from behavior analysis experts."
+- **Button Color**: `#E3B23C` (study theme yellow)
+
+#### Supervisors Page
+- **Title**: "Supervision Newsletter" 
+- **Description**: "Early access updates, supervision best practices, and resources for effective BCBA supervision."
+- **Button Color**: `#E3B23C` (supervision theme yellow)
+
+## Testing the Setup
+
+### 1. Check Ghost Connection
+```bash
+# Test if Ghost API is accessible
+curl "https://behaviorschool.com/ghost/api/content/posts/?key=YOUR_CONTENT_KEY&limit=1"
+```
+
+### 2. Verify Newsletter Signup
+1. Visit any landing page with the newsletter form
+2. Enter an email address
+3. Check Ghost Admin → Members to see if the subscription was recorded
+
+### 3. Development Testing
+```bash
+# Start development server
+npm run dev
+
+# Visit pages to test newsletter forms:
+# http://localhost:3000/products
+# http://localhost:3000/study  
+# http://localhost:3000/supervisors
+# http://localhost:3000/subscribe
+```
+
+## Troubleshooting
+
+### Newsletter Form Not Loading
+- Check browser console for JavaScript errors
+- Verify Ghost site is accessible at `https://behaviorschool.com`
+- Ensure Ghost newsletter feature is enabled in Ghost Admin
+
+### API Connection Issues
+- Verify `GHOST_CONTENT_URL` and `GHOST_CONTENT_KEY` in environment
+- Check Ghost Admin → Integrations for correct API key
+- Test API endpoint manually with curl/browser
+
+### Styling Issues
+- Newsletter forms inherit some styling from Ghost's default CSS
+- Custom styling can be applied via the component props
+- Check browser developer tools for CSS conflicts
+
+## Next Steps
+
+1. **Configure Environment**: Set up `.env.local` with actual Ghost credentials
+2. **Test Newsletter**: Verify signup forms work end-to-end
+3. **Email Setup**: Ensure Ghost email sending is configured (Settings → Email newsletter)
+4. **Design Newsletter**: Create newsletter templates in Ghost Admin
+5. **Analytics**: Set up tracking for newsletter signups (optional)
+
+## Technical Notes
+
+- Newsletter forms use Ghost's hosted JavaScript widget for maximum compatibility
+- Forms are responsive and work on all device sizes
+- Each landing page has a themed newsletter signup with relevant messaging
+- The `GhostNewsletterSignup` component is reusable across the site
+- All forms point to the same Ghost instance but can have different styling/messaging

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import { Bolt, BarChart3, ShieldCheck, Clock, Layers, BookOpen } from "lucide-react";
 import { motion } from "framer-motion";
+import GhostNewsletterSignup from "@/components/ghost-newsletter-signup";
 
 export default function ProductsPage() {
   return (
@@ -110,6 +111,22 @@ export default function ProductsPage() {
             </motion.div>
           ))}
         </motion.div>
+      </section>
+
+      {/* Newsletter Signup Section */}
+      <section className="mx-auto max-w-4xl px-6 lg:px-8 pb-20">
+        <div className="text-center mb-8">
+          <h2 className="text-3xl sm:text-4xl font-bold tracking-tight text-slate-900">Stay Updated</h2>
+          <p className="mt-3 text-slate-600 max-w-2xl mx-auto">Get the latest insights, product updates, and practical strategies delivered to your inbox.</p>
+        </div>
+        <div className="bg-white/80 ring-1 ring-slate-200/70 rounded-2xl p-8 shadow-[0_10px_40px_-15px_rgba(0,0,0,0.25)]">
+          <GhostNewsletterSignup
+            title="Behavior School Updates"
+            description="Join thousands of BCBAs getting weekly insights on effective behavior management and professional growth."
+            compact={true}
+            className="mx-auto"
+          />
+        </div>
       </section>
     </div>
   );

--- a/src/app/study/page.tsx
+++ b/src/app/study/page.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { ContainerScroll } from "@/components/ui/container-scroll-animation";
+import GhostNewsletterSignup from "@/components/ghost-newsletter-signup";
 
 export const metadata = {
   title: "Behavior School Study Platform",
@@ -96,7 +97,7 @@ export default function StudyPage() {
               <AccordionContent>We analyze your responses to adjust difficulty and surface the highest-impact items for your next session.</AccordionContent>
             </AccordionItem>
             <AccordionItem value="q2">
-              <AccordionTrigger>What’s included in the free trial?</AccordionTrigger>
+              <AccordionTrigger>What&apos;s included in the free trial?</AccordionTrigger>
               <AccordionContent>Full access to the core practice engine and analytics for a limited time—no credit card required.</AccordionContent>
             </AccordionItem>
             <AccordionItem value="q3">
@@ -104,6 +105,28 @@ export default function StudyPage() {
               <AccordionContent>Yes, dashboards show your mastery growth and time-to-target estimates by task area.</AccordionContent>
             </AccordionItem>
           </Accordion>
+        </div>
+      </section>
+
+      {/* Newsletter Signup Section */}
+      <section className="py-16" style={{ backgroundColor: '#FFF8EA' }}>
+        <div className="max-w-4xl mx-auto px-6">
+          <div className="text-center mb-8">
+            <h2 className="text-3xl font-bold text-slate-900">Study Smarter with Our Newsletter</h2>
+            <p className="mt-3 text-slate-600 max-w-2xl mx-auto">Get study tips, BCBA exam updates, and exclusive practice content delivered weekly.</p>
+          </div>
+          <div className="bg-white rounded-2xl p-8 shadow-[0_10px_40px_-15px_rgba(0,0,0,0.25)]">
+            <GhostNewsletterSignup
+              title="BCBA Study Newsletter"
+              description="Weekly study strategies, practice questions, and exam preparation tips from behavior analysis experts."
+              backgroundColor="#FFFFFF"
+              textColor="#1F4D3F"
+              buttonColor="#E3B23C"
+              buttonTextColor="#FFFFFF"
+              compact={true}
+              className="mx-auto"
+            />
+          </div>
         </div>
       </section>
     </div>

--- a/src/app/supervisors/page.tsx
+++ b/src/app/supervisors/page.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import GhostNewsletterSignup from "@/components/ghost-newsletter-signup";
 
 export const metadata = {
   title: "Behavior School Supervision Tools",
@@ -72,6 +73,28 @@ export default function SupervisorsPage() {
             <Button asChild size="lg" className="bg-[#E3B23C] hover:bg-[#d9a42f] text-slate-900">
               <Link href="https://study.behaviorschool.com/supervisors" target="_blank" rel="noopener noreferrer">Join the Waitlist</Link>
             </Button>
+          </div>
+        </div>
+      </section>
+
+      {/* Newsletter Signup Section */}
+      <section className="py-16" style={{ backgroundColor: '#FFF8EA' }}>
+        <div className="max-w-4xl mx-auto px-6">
+          <div className="text-center mb-8">
+            <h2 className="text-3xl font-bold text-slate-900">Stay Informed About Supervision Tools</h2>
+            <p className="mt-3 text-slate-600 max-w-2xl mx-auto">Get updates on our supervision platform launch, plus weekly insights on effective BCBA supervision practices.</p>
+          </div>
+          <div className="bg-white rounded-2xl p-8 shadow-[0_10px_40px_-15px_rgba(0,0,0,0.25)]">
+            <GhostNewsletterSignup
+              title="Supervision Newsletter"
+              description="Early access updates, supervision best practices, and resources for effective BCBA supervision."
+              backgroundColor="#FFFFFF"
+              textColor="#1F4D3F"
+              buttonColor="#E3B23C"
+              buttonTextColor="#FFFFFF"
+              compact={true}
+              className="mx-auto"
+            />
           </div>
         </div>
       </section>

--- a/src/components/ghost-newsletter-signup.tsx
+++ b/src/components/ghost-newsletter-signup.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import Script from "next/script"
+import { cn } from "@/lib/utils"
+
+interface GhostNewsletterSignupProps {
+  className?: string
+  title?: string
+  description?: string
+  backgroundColor?: string
+  textColor?: string
+  buttonColor?: string
+  buttonTextColor?: string
+  compact?: boolean
+  showIcon?: boolean
+}
+
+export default function GhostNewsletterSignup({
+  className,
+  title = "Join Our Newsletter",
+  description = "Get exclusive insights, actionable strategies, and the support you need to lead with confidence and create lasting change.",
+  backgroundColor = "#ffffff",
+  textColor = "#000000",
+  buttonColor = "#dfbf7c",
+  buttonTextColor = "#FFFFFF",
+  compact = false,
+  showIcon = true
+}: GhostNewsletterSignupProps) {
+  const height = compact ? "300px" : "400px"
+  const minHeight = compact ? 300 : 360
+
+  return (
+    <div className={cn("w-full", className)}>
+      <div 
+        style={{ height, minHeight }} 
+        className="w-full max-w-md mx-auto"
+      >
+        <Script
+          src="https://cdn.jsdelivr.net/ghost/signup-form@~0.2/umd/signup-form.min.js"
+          async
+          data-background-color={backgroundColor}
+          data-text-color={textColor}
+          data-button-color={buttonColor}
+          data-button-text-color={buttonTextColor}
+          data-title={title}
+          data-description={description}
+          data-icon={showIcon ? "https://behaviorschool.com/content/images/size/w192h192/size/w256h256/2025/02/Behavior-School-Logo.png" : ""}
+          data-site="https://behaviorschool.com/"
+          data-locale="en"
+        />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Integrate Ghost newsletter signup forms across landing pages and add a Ghost setup guide.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b7516f4-9de9-4e4b-ada5-c536ace47154">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8b7516f4-9de9-4e4b-ada5-c536ace47154">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

