### PR TITLE
Integrate ghost newsletter signup for landing pages

### DIFF
--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import { Bolt, BarChart3, ShieldCheck, Clock, Layers, BookOpen } from "lucide-react";
 import { motion } from "framer-motion";
+import { GhostSignup } from "@/components/ghost-signup";
 
 export default function ProductsPage() {
   return (
@@ -110,6 +111,17 @@ export default function ProductsPage() {
             </motion.div>
           ))}
         </motion.div>
+      </section>
+
+      {/* Newsletter CTA */}
+      <section className="mx-auto max-w-6xl px-6 lg:px-8 pb-20">
+        <div className="text-center mb-6">
+          <h2 className="text-3xl font-bold text-slate-900">Get updates and resources</h2>
+          <p className="text-slate-600 mt-2">Join the newsletter for product updates, resources, and early access invites.</p>
+        </div>
+        <div className="max-w-md mx-auto">
+          <GhostSignup />
+        </div>
       </section>
     </div>
   );

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -1,6 +1,7 @@
 export const dynamic = "force-dynamic";
 import Link from "next/link";
 import { getPosts, type Post } from "@/lib/ghost";
+import { GhostSignup } from "@/components/ghost-signup";
 
 function PostRow({ post }: { post: Post }) {
   return (
@@ -22,6 +23,15 @@ export default async function ResourcesPage() {
         {posts.map((post) => (
           <PostRow key={post.id} post={post} />
         ))}
+      </div>
+      <div className="mt-12">
+        <div className="text-center mb-4">
+          <h2 className="text-2xl font-semibold text-slate-900">Get new resources in your inbox</h2>
+          <p className="text-slate-600 mt-2">Join the newsletter for fresh posts, tools, and actionable insights.</p>
+        </div>
+        <div className="max-w-md mx-auto">
+          <GhostSignup />
+        </div>
       </div>
     </div>
   );

--- a/src/app/study/page.tsx
+++ b/src/app/study/page.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { ContainerScroll } from "@/components/ui/container-scroll-animation";
+import { GhostSignup } from "@/components/ghost-signup";
 
 export const metadata = {
   title: "Behavior School Study Platform",
@@ -104,6 +105,19 @@ export default function StudyPage() {
               <AccordionContent>Yes, dashboards show your mastery growth and time-to-target estimates by task area.</AccordionContent>
             </AccordionItem>
           </Accordion>
+        </div>
+      </section>
+
+      {/* Newsletter CTA */}
+      <section className="py-16">
+        <div className="max-w-6xl mx-auto px-6">
+          <div className="text-center mb-6">
+            <h2 className="text-3xl font-bold text-slate-900">Get BCBA study tips and product updates</h2>
+            <p className="text-slate-600 mt-2">Join the newsletter for practice strategies, study planning tips, and early access features.</p>
+          </div>
+          <div className="max-w-md mx-auto">
+            <GhostSignup />
+          </div>
         </div>
       </section>
     </div>

--- a/src/app/supervisors/page.tsx
+++ b/src/app/supervisors/page.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { GhostSignup } from "@/components/ghost-signup";
 
 export const metadata = {
   title: "Behavior School Supervision Tools",
@@ -72,6 +73,19 @@ export default function SupervisorsPage() {
             <Button asChild size="lg" className="bg-[#E3B23C] hover:bg-[#d9a42f] text-slate-900">
               <Link href="https://study.behaviorschool.com/supervisors" target="_blank" rel="noopener noreferrer">Join the Waitlist</Link>
             </Button>
+          </div>
+        </div>
+      </section>
+
+      {/* Newsletter CTA */}
+      <section className="py-16">
+        <div className="max-w-6xl mx-auto px-6">
+          <div className="text-center mb-6">
+            <h2 className="text-3xl font-bold text-slate-900">Get supervision resources and updates</h2>
+            <p className="text-slate-600 mt-2">Join the newsletter for templates, workflows, and early access to supervision tools.</p>
+          </div>
+          <div className="max-w-md mx-auto">
+            <GhostSignup />
           </div>
         </div>
       </section>

--- a/src/components/ghost-signup.tsx
+++ b/src/components/ghost-signup.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import Script from "next/script"
+import React from "react"
+
+export type GhostSignupProps = {
+  site?: string
+  title?: string
+  description?: string
+  icon?: string
+  backgroundColor?: string
+  textColor?: string
+  buttonColor?: string
+  buttonTextColor?: string
+  locale?: string
+  className?: string
+  style?: React.CSSProperties
+}
+
+export function GhostSignup({
+  site = "https://behaviorschool.com/",
+  title = "Behavior School",
+  description = "We help overwhelmed BCBAs create structured behavior systems for student success",
+  icon = "https://behaviorschool.com/content/images/size/w192h192/size/w256h256/2025/02/Behavior-School-Logo.png",
+  backgroundColor = "#ffffff",
+  textColor = "#000000",
+  buttonColor = "#dfbf7c",
+  buttonTextColor = "#FFFFFF",
+  locale = "en",
+  className,
+  style,
+}: GhostSignupProps) {
+  return (
+    <div
+      className={className}
+      style={{ height: "40vmin", minHeight: 360, ...style }}
+    >
+      <Script
+        src="https://cdn.jsdelivr.net/ghost/signup-form@~0.2/umd/signup-form.min.js"
+        async
+        data-background-color={backgroundColor}
+        data-text-color={textColor}
+        data-button-color={buttonColor}
+        data-button-text-color={buttonTextColor}
+        data-title={title}
+        data-description={description}
+        data-icon={icon}
+        data-site={site}
+        data-locale={locale}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
Adds Ghost newsletter signup forms to the products, study, supervisors, and resources landing pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-24362b1f-eef9-437e-9eb9-82a5877e8baf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24362b1f-eef9-437e-9eb9-82a5877e8baf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

