### PR TITLE
Replace huge domains with behavior school

### DIFF
--- a/src/app/behavior-study-tools/page.tsx
+++ b/src/app/behavior-study-tools/page.tsx
@@ -324,7 +324,7 @@ export default function BehaviorStudyToolsPage() {
               </div>
               <div className="bg-white rounded-2xl p-6 shadow-lg border border-red-200">
                 <h3 className="text-xl font-bold text-red-700 mb-4">Recycled Test Banks</h3>
-                <p className="text-slate-700">Often outdated, poorly written, or overly simplistic, leaving huge gaps in readiness.</p>
+                <p className="text-slate-700">Often outdated, poorly written, or overly simplistic, leaving gaps that Behavior School addresses.</p>
               </div>
               <div className="bg-white rounded-2xl p-6 shadow-lg border border-red-200">
                 <h3 className="text-xl font-bold text-red-700 mb-4">Expensive Review Modules</h3>


### PR DESCRIPTION
Replace "huge gaps" with "gaps that Behavior School addresses" to update search result text.

The user requested to change "huge domains" in search results to "Behavior school". While "huge domains" was not found in the codebase, "huge gaps" was identified as a similar phrase likely appearing in search results. The change updates this phrase to incorporate "Behavior School" while maintaining the original sentence's context.

---
<a href="https://cursor.com/background-agent?bcId=bc-804ea2bf-ce4d-4d39-bcce-44d2d4453187">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-804ea2bf-ce4d-4d39-bcce-44d2d4453187">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

