### PR TITLE
Replace huge domains with behavior school

### DIFF
--- a/src/app/act-matrix/layout.tsx
+++ b/src/app/act-matrix/layout.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
+  applicationName: "Behavior School ACT Matrix",
   title: "ACT Matrix for Schools | Free PDF Download & Examples | Behavior School",
   description: "Complete ACT Matrix guide for school-based behavior analysts. Free PDF download with examples, explained step-by-step. Learn how the ACT Matrix improves student values-based interventions in schools.",
 };

--- a/src/app/act-matrix/page.tsx
+++ b/src/app/act-matrix/page.tsx
@@ -5,6 +5,7 @@ import { Download, CheckCircle, Target, Users, BookOpen } from "lucide-react";
 import Link from "next/link";
 
 export const metadata: Metadata = {
+  applicationName: "Behavior School ACT Matrix",
   title: "ACT Matrix for Schools | Free PDF Download & Examples | Behavior School",
   description: "Complete ACT Matrix guide for school-based behavior analysts. Free PDF download with examples, explained step-by-step. Learn how the ACT Matrix improves student values-based interventions in schools.",
   robots: {
@@ -41,6 +42,7 @@ export const metadata: Metadata = {
     description: "Complete ACT Matrix guide for school-based behavior analysts. Free PDF download with examples, explained step-by-step. Learn how the ACT Matrix improves student values-based interventions in schools.",
     type: "website", 
     url: "https://behaviorschool.com/act-matrix",
+    siteName: "Behavior School ACT Matrix",
     images: [
       {
         url: "https://behaviorschool.com/thumbnails/act-matrix-thumb.webp",
@@ -54,6 +56,8 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "ACT Matrix for Schools | Free PDF Download & Examples | Behavior School",
     description: "Complete ACT Matrix guide for school-based behavior analysts. Free PDF download with examples, explained step-by-step. Learn how the ACT Matrix improves student values-based interventions in schools.",
+    site: "@BehaviorSchool",
+    creator: "@BehaviorSchool",
     images: ["https://behaviorschool.com/thumbnails/act-matrix-thumb.webp"]
   },
   alternates: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { PrivacyCompliantAnalytics } from "@/components/analytics/PrivacyComplia
 import Script from "next/script";
 
 export const metadata: Metadata = {
+  applicationName: "Behavior School",
   title: "BCBA Training & Exam Prep for School-Based Behavior Analysts | Behavior School",
   description: "Comprehensive BCBA exam prep and school behavior support tools for behavior analysts. Get AI-powered practice tests, supervision tools, IEP goal templates, and proven training programs. Try free.",
   keywords: ["behavior change", "leadership", "productivity", "burnout prevention"],


### PR DESCRIPTION
Update SEO metadata to explicitly brand search results as "Behavior School" or "Behavior School ACT Matrix".

This change prevents search engines from displaying "Huge Domains" by setting `applicationName` globally and specific `applicationName`, `openGraph.siteName`, and Twitter metadata for the ACT Matrix page.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a042320-de16-4648-aee6-3e84a60ac1a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a042320-de16-4648-aee6-3e84a60ac1a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

