### PR TITLE
Remove huge domains

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import Script from "next/script";
 export const metadata: Metadata = {
   title: "BCBA Training & Exam Prep for School-Based Behavior Analysts | Behavior School",
   description: "Comprehensive BCBA exam prep and school behavior support tools for behavior analysts. Get AI-powered practice tests, supervision tools, IEP goal templates, and proven training programs. Try free.",
+  applicationName: "Behavior School",
   keywords: ["behavior change", "leadership", "productivity", "burnout prevention"],
   authors: [{ name: "Behavior School" }],
   viewport: "width=device-width, initial-scale=1",
@@ -38,6 +39,11 @@ export const metadata: Metadata = {
     title: "BCBA Training & Exam Prep for School-Based Behavior Analysts | Behavior School",
     description: "Comprehensive BCBA exam prep and school behavior support tools for behavior analysts. Get AI-powered practice tests, supervision tools, IEP goal templates, and proven training programs.",
     images: ["/optimized/og-image.webp"],
+  },
+  appleWebApp: {
+    title: "Behavior School",
+    capable: true,
+    statusBarStyle: "default",
   },
   metadataBase: new URL("https://behaviorschool.com"),
   other: {


### PR DESCRIPTION
Add explicit site branding metadata to `layout.tsx` to prevent "HugeDomains" from appearing in search results.

---
<a href="https://cursor.com/background-agent?bcId=bc-1370adad-3e78-413f-8953-9bb445dee461">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1370adad-3e78-413f-8953-9bb445dee461">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

