### PR TITLE
Fix broken link to ACT matrix page

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
 https://www.behaviorschool.com/* https://behaviorschool.com/:splat 301!
+/the-act-matrix-a-framework-for-school-based-bcbas /act-matrix 301

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -42,6 +42,12 @@
     <priority>0.85</priority>
   </url>
   <url>
+    <loc>https://behaviorschool.com/act-matrix</loc>
+    <lastmod>2025-08-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.85</priority>
+  </url>
+  <url>
     <loc>https://behaviorschool.com/behavior-plans</loc>
     <lastmod>2025-08-25</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
Add 301 redirect for a broken ACT Matrix URL and include the new path in the sitemap to fix a 404 error and update search engines.

---
<a href="https://cursor.com/background-agent?bcId=bc-174d5f08-bc4b-4ea6-89d4-08c9e5991dbe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-174d5f08-bc4b-4ea6-89d4-08c9e5991dbe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

