### PR TITLE
Replace huge domains with behavior school

### DIFF
--- a/src/app/act-matrix/page.tsx
+++ b/src/app/act-matrix/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 export const metadata: Metadata = {
   title: "ACT Matrix for Schools | Free PDF Download & Examples | Behavior School",
   description: "Complete ACT Matrix guide for school-based behavior analysts. Free PDF download with examples, explained step-by-step. Learn how the ACT Matrix improves student values-based interventions in schools.",
+  applicationName: "Behavior School",
   robots: {
     index: true,
     follow: true,
@@ -41,6 +42,7 @@ export const metadata: Metadata = {
     description: "Complete ACT Matrix guide for school-based behavior analysts. Free PDF download with examples, explained step-by-step. Learn how the ACT Matrix improves student values-based interventions in schools.",
     type: "website", 
     url: "https://behaviorschool.com/act-matrix",
+    siteName: "Behavior School",
     images: [
       {
         url: "https://behaviorschool.com/thumbnails/act-matrix-thumb.webp",
@@ -101,6 +103,19 @@ const structuredData = {
       "name": "School-based behavior analysis"
     }
   ]
+};
+
+// WebPage schema to reinforce correct site/page naming in search results
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Behavior School ACT Matrix",
+  "url": "https://behaviorschool.com/act-matrix",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Behavior School",
+    "url": "https://behaviorschool.com"
+  }
 };
 
 // HowTo Schema for using ACT Matrix
@@ -210,6 +225,10 @@ export default function ACTMatrixPage() {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPageSchema) }}
       />
       
       <div className="min-h-screen bg-white">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import Script from "next/script";
 export const metadata: Metadata = {
   title: "BCBA Training & Exam Prep for School-Based Behavior Analysts | Behavior School",
   description: "Comprehensive BCBA exam prep and school behavior support tools for behavior analysts. Get AI-powered practice tests, supervision tools, IEP goal templates, and proven training programs. Try free.",
+  applicationName: "Behavior School",
   keywords: ["behavior change", "leadership", "productivity", "burnout prevention"],
   authors: [{ name: "Behavior School" }],
   viewport: "width=device-width, initial-scale=1",


### PR DESCRIPTION
Update site metadata to correctly display "Behavior School" or "Behavior School ACT Matrix" in search results.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b8d87d7-0523-41eb-8845-42eea005bfb3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4b8d87d7-0523-41eb-8845-42eea005bfb3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

