### PR TITLE
[codex] Allow Study origins for marketing events CORS

### DIFF
--- a/src/app/api/behavior-study-tools/marketing-events/route.ts
+++ b/src/app/api/behavior-study-tools/marketing-events/route.ts
@@ -7,6 +7,7 @@ const allowedOrigins = new Set([
   'https://behaviorstudytools.com',
   'https://www.behaviorstudytools.com',
   'https://study.behaviorschool.com',
+  'https://main--behaviorstudytool.netlify.app',
   'http://localhost:5173',
   'http://localhost:5174',
   'http://localhost:3000',
@@ -15,12 +16,29 @@ const allowedOrigins = new Set([
   'http://127.0.0.1:3000',
 ])
 
+function isAllowedOrigin(origin: string | null) {
+  if (!origin) return false
+  if (allowedOrigins.has(origin)) return true
+
+  try {
+    const { hostname, protocol } = new URL(origin)
+    return protocol === 'https:' && /^deploy-preview-\d+--behaviorstudytool\.netlify\.app$/.test(hostname)
+  } catch {
+    return false
+  }
+}
+
+function resolveAllowedOrigin(origin: string | null) {
+  return origin && isAllowedOrigin(origin) ? origin : 'https://behaviorstudytools.com'
+}
+
 function corsHeaders(origin: string | null) {
-  const allowedOrigin = origin && allowedOrigins.has(origin) ? origin : 'https://behaviorstudytools.com'
+  const allowedOrigin = resolveAllowedOrigin(origin)
   return {
     'Access-Control-Allow-Origin': allowedOrigin,
     'Access-Control-Allow-Methods': 'POST, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Credentials': 'true',
     'Access-Control-Max-Age': '86400',
   }
 }


### PR DESCRIPTION
## Summary
- Allows Study production (`study.behaviorschool.com`) to POST Behavior Study Tools marketing events to the Behaviorschool endpoint.
- Allows the Study Netlify main and deploy-preview origins used for QA.
- Adds `Access-Control-Allow-Credentials: true` because Study sends the marketing event request with credentials included.
- Keeps the preview allowance bounded to `deploy-preview-N--behaviorstudytool.netlify.app` instead of allowing every Netlify app origin.

## Root Cause
Study PR #59 restored PWA service worker registration and fixed Study's CSP to permit `https://behaviorschool.com`. Browser QA then surfaced the next blocker: `https://behaviorschool.com/api/behavior-study-tools/marketing-events` returned CORS headers for `https://behaviorstudytools.com`, so Study production/previews were rejected at preflight. Production Study also requires `Access-Control-Allow-Credentials: true` because the browser request uses credentials mode `include`.

## Validation
- Static origin predicate/header check passed for `https://study.behaviorschool.com`, including:
  - `Access-Control-Allow-Origin: https://study.behaviorschool.com`
  - `Access-Control-Allow-Credentials: true`
- Static origin predicate check passed for:
  - `https://main--behaviorstudytool.netlify.app`
  - `https://deploy-preview-59--behaviorstudytool.netlify.app`
  - rejected non-preview and non-HTTPS preview lookalikes
- `git diff --check` passed.

## Notes
The original checkout has unrelated dirty files, so this PR was made from a clean worktree at `origin/main`.
